### PR TITLE
Fixes RCE security issue by adding shell argument escaping

### DIFF
--- a/src/Pygmentize/Pygmentize.php
+++ b/src/Pygmentize/Pygmentize.php
@@ -45,12 +45,18 @@ class Pygmentize {
         2 => array('pipe', 'w'), // stderr
       );
 
-      if (!empty($language))
-        $args = sprintf(" -f %s -l %s -O encoding=%s,style=%s,lineos=1,startinline=true", $formatter, $language, $encoding, $style);
-      else
-        $args = sprintf(" -f %s -g -O encoding=%s,style=%s,lineos=1", $formatter, $encoding, $style);
+      $args = array(
+        '-f ' . escapeshellarg($formatter)
+      );
+      if (!empty($language)) {
+        $args[] = '-l ' . escapeshellarg($language);
+        $args[] = '-O ' . escapeshellarg(sprintf('encoding=%s,style=%s,lineos=1,startinline=true', $encoding, $style));
+      } else {
+        $args[] = '-g';
+        $args[] = '-O ' . escapeshellarg(sprintf('encoding=%s,style=%s,lineos=1', $encoding, $style));
+      }
 
-      $proc = proc_open(self::PIGMENTS_BINARY.$args, $dspec, $pipes);
+      $proc = proc_open(self::PIGMENTS_BINARY.implode(' ', $args), $dspec, $pipes);
 
       if (is_resource($proc)) {
         // Reads the stdout output.

--- a/src/Pygmentize/Pygmentize.php
+++ b/src/Pygmentize/Pygmentize.php
@@ -56,7 +56,7 @@ class Pygmentize {
         $args[] = '-O ' . escapeshellarg(sprintf('encoding=%s,style=%s,lineos=1', $encoding, $style));
       }
 
-      $proc = proc_open(self::PIGMENTS_BINARY.implode(' ', $args), $dspec, $pipes);
+      $proc = proc_open(self::PIGMENTS_BINARY.' '.implode(' ', $args), $dspec, $pipes);
 
       if (is_resource($proc)) {
         // Reads the stdout output.


### PR DESCRIPTION
fixes #1, alternative to #2 by @h4ckninja, using `escapeshellarg` on the single arguments.

See also https://github.com/FriendsOfPHP/security-advisories/pull/178